### PR TITLE
dark mode is now saved in local storage

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10004,6 +10004,21 @@
         "json5": "^2.1.2"
       }
     },
+    "local-storage-fallback": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/local-storage-fallback/-/local-storage-fallback-4.1.1.tgz",
+      "integrity": "sha512-Ka4rem1FOgvIaPMokxXTP8DgW8gjfAQSdJC8TGrplDug7vh3b0PZnY/9euG3O3cIGAvJLp33mMU6MJ13x6S+Pw==",
+      "requires": {
+        "cookie": "^0.3.1"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        }
+      }
+    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "axios": "^0.21.0",
+    "local-storage-fallback": "^4.1.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",

--- a/client/src/components/LightDark/LightDarkToggle.jsx
+++ b/client/src/components/LightDark/LightDarkToggle.jsx
@@ -1,11 +1,25 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import LightDarkMode from "./LightDarkMode";
 import { ThemeProvider } from "styled-components";
 import { FormControlLabel, Switch, FormGroup } from '@material-ui/core';
 import NightsStayIcon from '@material-ui/icons/NightsStay';
+import Brightness5OutlinedIcon from '@material-ui/icons/Brightness5Outlined';
+import storage from 'local-storage-fallback';
+
+
+function getInitialTheme() {
+  const savedTheme = storage.getItem('theme')
+  return savedTheme ? JSON.parse(savedTheme) : {mode: 'light'}
+}
 
 const LightDarkToggle = () => {
-  const [theme, setTheme] = useState({ mode: "light" });
+  const [theme, setTheme] = useState(getInitialTheme);
+  useEffect(
+    () => {
+      storage.setItem('theme', JSON.stringify(theme));
+    },
+    [theme]
+  );
   return (
     <div className="lightDarkToggle">
       <ThemeProvider theme={theme}>
@@ -17,7 +31,7 @@ const LightDarkToggle = () => {
         setTheme(
           theme.mode === "dark" ? { mode: "light" } : { mode: "dark" }
         )} />}
-        label={<NightsStayIcon fontSize='small'/>} /> 
+        label={theme.mode === 'light' ? <NightsStayIcon fontSize='small'/> : <Brightness5OutlinedIcon fontSize='small'/>} /> 
 
         </FormGroup>
       </ThemeProvider>


### PR DESCRIPTION
added light/dark mode to be saved internally. I added npm package 'local-storage-fallback'. You'll have to run npm i on your end to get the package working. 